### PR TITLE
fix double write line to csv

### DIFF
--- a/scripts/clip_interrogator_ext.py
+++ b/scripts/clip_interrogator_ext.py
@@ -42,7 +42,6 @@ class BatchWriter:
         elif self.mode == BATCH_OUTPUT_MODES[1]:
             self.file.write(f"{prompt}\n")
         elif self.mode == BATCH_OUTPUT_MODES[2]:
-            self.file.write(f"{file},{prompt}\n")
             self.csv.writerow([file, prompt])
 
     def close(self):


### PR DESCRIPTION
Annoying error, the file name and promt line are written twice to the cvs file: first as simple string write to file, then second time through cvs module row write.